### PR TITLE
CORS header "Access-Control-Allow-Origin: *" is added to every response

### DIFF
--- a/main/Main.hs
+++ b/main/Main.hs
@@ -6,10 +6,13 @@ import Yesod
 import WebBackend
 import Data.IORef
 import Data.Maybe
+import Network.Wai.Handler.Warp
+import Network.Wai.Middleware.Cors
 import Shoebox.Interface
 
 main :: IO ()
 main = do
 	shoeDB <- shoeReadDB "frz"
 	ref <- newIORef (fromJust shoeDB)
-	warp 3000 (ShoeWeb ref)
+	shoeApp <- toWaiApp (ShoeWeb ref)
+	run 3000 $ simpleCors shoeApp

--- a/shoebox.cabal
+++ b/shoebox.cabal
@@ -39,6 +39,8 @@ executable shoe
                      , strict
                      , split
                      , containers
+                     , wai-cors
+                     , warp
   other-modules:       WebBackend
   hs-source-dirs:      main
   default-language:    Haskell2010


### PR DESCRIPTION
Browsers basically do not permit AJAX requests from one origin to another. That is the Shoebox UI cannot access the backend if they are not both served from the same origin. A simple solution is to set the CORS header accordingly to allow this nonetheless.